### PR TITLE
Dashboard & AI UX improvements

### DIFF
--- a/src-tauri/src/state/dashboard.rs
+++ b/src-tauri/src/state/dashboard.rs
@@ -57,6 +57,8 @@ pub struct WarningEvent {
     pub reason: String,
     pub message: String,
     pub involved_object: String,
+    pub object_kind: String,
+    pub object_name: String,
     pub namespace: String,
     pub count: i64,
     pub last_seen: String,
@@ -259,16 +261,22 @@ pub fn compute_health(
         })
         .take(20)
         .map(|e| {
-            let involved = e
-                .pointer("/involvedObject")
-                .map(|io| {
-                    format!(
-                        "{}/{}",
-                        io.get("kind").and_then(|v| v.as_str()).unwrap_or(""),
-                        io.get("name").and_then(|v| v.as_str()).unwrap_or("")
-                    )
-                })
-                .unwrap_or_default();
+            let io = e.pointer("/involvedObject");
+            let obj_kind = io
+                .and_then(|o| o.get("kind"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let obj_name = io
+                .and_then(|o| o.get("name"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let involved = if !obj_kind.is_empty() || !obj_name.is_empty() {
+                format!("{}/{}", obj_kind, obj_name)
+            } else {
+                String::new()
+            };
 
             WarningEvent {
                 reason: e
@@ -282,6 +290,8 @@ pub fn compute_health(
                     .unwrap_or("")
                     .to_string(),
                 involved_object: involved,
+                object_kind: obj_kind,
+                object_name: obj_name,
                 namespace: e
                     .pointer("/metadata/namespace")
                     .and_then(|v| v.as_str())

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -578,7 +578,7 @@ export default function App() {
             <section className="overflow-hidden relative">
               <AnimatePresence mode="wait">
                 {viewMode === "chat" ? (
-                  <AIChatView key="chat" namespace={namespace === "*" ? undefined : namespace} />
+                  <AIChatView key="chat" namespace={namespace === "*" ? undefined : namespace} onGoToSettings={() => setViewMode("settings")} />
                 ) : viewMode === "dashboard" ? (
                   <ClusterDashboard
                     key="dashboard"
@@ -596,6 +596,7 @@ export default function App() {
                     key="network-policies"
                     namespace={namespace === "*" ? undefined : namespace}
                     currentContext={currentContext}
+                    onGoToSettings={() => setViewMode("settings")}
                   />
                 ) : viewMode === "rbac" ? (
                   <RbacView
@@ -709,6 +710,7 @@ export default function App() {
             ? { kind, namespace: selected.namespace || "default", name: selected.name }
             : undefined
         }
+        onGoToSettings={() => setViewMode("settings")}
       />
     </div>
   );

--- a/src/components/ai-chat-view.tsx
+++ b/src/components/ai-chat-view.tsx
@@ -36,6 +36,7 @@ interface DisplayMessage {
 
 interface AIChatViewProps {
   namespace?: string;
+  onGoToSettings?: () => void;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────
@@ -78,7 +79,7 @@ const suggestions = [
 
 // ── Component ────────────────────────────────────────────────────────────
 
-export function AIChatView({ namespace }: AIChatViewProps) {
+export function AIChatView({ namespace, onGoToSettings }: AIChatViewProps) {
   const [messages, setMessages] = useState<DisplayMessage[]>([]);
   const [input, setInput] = useState("");
   const [isStreaming, setIsStreaming] = useState(false);
@@ -263,7 +264,7 @@ export function AIChatView({ namespace }: AIChatViewProps) {
       </div>
 
       {/* Configuration Warning */}
-      {!isConfigured && <AIConfigWarning className="px-6 shrink-0" />}
+      {!isConfigured && <AIConfigWarning className="px-6 shrink-0" onGoToSettings={onGoToSettings} />}
 
       {/* Messages area */}
       <div className="flex-1 overflow-y-auto">

--- a/src/components/ai-config-warning.tsx
+++ b/src/components/ai-config-warning.tsx
@@ -1,17 +1,30 @@
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface AIConfigWarningProps {
   className?: string;
+  onGoToSettings?: () => void;
 }
 
-export function AIConfigWarning({ className }: AIConfigWarningProps) {
+export function AIConfigWarning({ className, onGoToSettings }: AIConfigWarningProps) {
   return (
     <div className={cn("px-4 py-2.5 border-b border-slate-800/50 bg-amber-500/5", className)}>
       <div className="flex items-center gap-2 text-xs">
         <AlertCircle className="w-3.5 h-3.5 text-amber-400 shrink-0" />
         <span className="text-amber-300/90">
-          Configure an AI provider in Settings to use this feature
+          Configure an AI provider in{" "}
+          {onGoToSettings ? (
+            <button
+              onClick={onGoToSettings}
+              className="inline-flex items-center gap-1 align-middle text-accent hover:text-accent/80 transition-colors"
+            >
+              <Settings className="w-3 h-3 -mt-px" />
+              Settings
+            </button>
+          ) : (
+            "Settings"
+          )}{" "}
+          to use this feature
         </span>
       </div>
     </div>

--- a/src/components/ai-panel.tsx
+++ b/src/components/ai-panel.tsx
@@ -34,6 +34,7 @@ interface AIPanelProps {
   open: boolean;
   onClose: () => void;
   resourceContext?: { kind: string; namespace: string; name: string };
+  onGoToSettings?: () => void;
 }
 
 // Placeholder for the backend invoke — imported from api.ts in production
@@ -63,7 +64,7 @@ const quickActions = [
 
 // ── Component ────────────────────────────────────────────────────────────
 
-export function AIPanel({ open, onClose, resourceContext }: AIPanelProps) {
+export function AIPanel({ open, onClose, resourceContext, onGoToSettings }: AIPanelProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const [isStreaming, setIsStreaming] = useState(false);
@@ -278,7 +279,7 @@ export function AIPanel({ open, onClose, resourceContext }: AIPanelProps) {
             </div>
 
             {/* Configuration Warning */}
-            {!isConfigured && <AIConfigWarning className="w-full" />}
+            {!isConfigured && <AIConfigWarning className="w-full" onGoToSettings={onGoToSettings} />}
 
             {/* Resource Context Indicator */}
             {resourceContext && (

--- a/src/components/cluster-dashboard.tsx
+++ b/src/components/cluster-dashboard.tsx
@@ -116,6 +116,21 @@ function PieTooltipContent({
   );
 }
 
+// ── Kind mapping ────────────────────────────────────────────────────
+
+const KIND_TO_RESOURCE: Record<string, string> = {
+  Pod: "pods",
+  Deployment: "deployments",
+  Service: "services",
+  Node: "nodes",
+  Ingress: "ingresses",
+  Job: "jobs",
+  CronJob: "cronjobs",
+  ConfigMap: "configmaps",
+  Secret: "secrets",
+  ReplicaSet: "deployments",
+};
+
 // ── Health cards (shared between single and multi-cluster) ───────────
 
 function HealthCards({
@@ -355,27 +370,40 @@ function HealthCards({
           </div>
         ) : (
           <div className="space-y-2 overflow-auto max-h-48">
-            {health.recent_warnings.map((evt, idx) => (
-              <div
-                key={`${evt.involved_object}-${evt.reason}-${idx}`}
-                className="px-2 py-1.5 rounded border border-amber-500/10 bg-amber-500/5 text-xs"
-              >
-                <div className="flex items-center gap-1.5">
-                  <AlertTriangle className="w-3 h-3 text-amber-400 flex-shrink-0" />
-                  <span className="text-amber-300 font-medium truncate">{evt.reason}</span>
-                  {evt.count > 1 && (
-                    <span className="text-slate-500 font-mono text-[10px] ml-auto flex-shrink-0">
-                      x{evt.count}
-                    </span>
-                  )}
+            {health.recent_warnings.map((evt, idx) => {
+              const resourceKind = KIND_TO_RESOURCE[evt.object_kind];
+              const canNavigate = !!(resourceKind && evt.object_name && onNavigateToResource);
+              return (
+                <div
+                  key={`${evt.involved_object}-${evt.reason}-${idx}`}
+                  className="px-2 py-1.5 rounded border border-amber-500/10 bg-amber-500/5 text-xs"
+                >
+                  <div className="flex items-center gap-1.5">
+                    <AlertTriangle className="w-3 h-3 text-amber-400 flex-shrink-0" />
+                    <span className="text-amber-300 font-medium truncate">{evt.reason}</span>
+                    {evt.count > 1 && (
+                      <span className="text-slate-500 font-mono text-[10px] ml-auto flex-shrink-0">
+                        x{evt.count}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-slate-400 mt-0.5 line-clamp-2 leading-relaxed">{evt.message}</p>
+                  <div className="flex items-center justify-between mt-1 text-[10px] text-slate-600">
+                    {canNavigate ? (
+                      <button
+                        onClick={() => onNavigateToResource!(resourceKind, evt.object_name, evt.namespace)}
+                        className="truncate max-w-[60%] text-accent hover:text-accent/80 transition-colors"
+                      >
+                        {evt.involved_object}
+                      </button>
+                    ) : (
+                      <span className="truncate max-w-[60%]">{evt.involved_object}</span>
+                    )}
+                    <span>{evt.last_seen}</span>
+                  </div>
                 </div>
-                <p className="text-slate-400 mt-0.5 line-clamp-2 leading-relaxed">{evt.message}</p>
-                <div className="flex items-center justify-between mt-1 text-[10px] text-slate-600">
-                  <span className="truncate max-w-[60%]">{evt.involved_object}</span>
-                  <span>{evt.last_seen}</span>
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </DashboardCard>

--- a/src/components/cluster-dashboard.tsx
+++ b/src/components/cluster-dashboard.tsx
@@ -52,12 +52,16 @@ function DashboardCard({
   icon: Icon,
   children,
   className,
+  tooltip,
 }: {
   title: string;
   icon: React.ElementType;
   children: React.ReactNode;
   className?: string;
+  tooltip?: string;
 }) {
+  const [showTooltip, setShowTooltip] = useState(false);
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 12 }}
@@ -68,6 +72,20 @@ function DashboardCard({
       <div className="flex items-center gap-2 mb-3">
         <Icon className="w-4 h-4 text-accent" />
         <h3 className="text-sm font-semibold text-slate-200 tracking-wide uppercase">{title}</h3>
+        {tooltip && (
+          <div
+            className="relative"
+            onMouseEnter={() => setShowTooltip(true)}
+            onMouseLeave={() => setShowTooltip(false)}
+          >
+            <Info className="w-3.5 h-3.5 text-slate-500 hover:text-slate-300 transition-colors cursor-help" />
+            {showTooltip && (
+              <div className="absolute left-1/2 -translate-x-1/2 top-full mt-1.5 z-50 w-56 px-3 py-2 text-[11px] leading-relaxed text-slate-300 bg-surface border border-slate-700 rounded-md shadow-lg pointer-events-none">
+                {tooltip}
+              </div>
+            )}
+          </div>
+        )}
       </div>
       <div className="flex-1 min-h-0">{children}</div>
     </motion.div>
@@ -97,92 +115,6 @@ function PieTooltipContent({
   );
 }
 
-// ── Score breakdown ──────────────────────────────────────────────────
-
-function ScoreBreakdown({ health }: { health: ClusterHealth }) {
-  const readyNodes = health.nodes.filter((n) => n.status === "Ready").length;
-  const totalNodes = Math.max(health.nodes.length, 1);
-  const nodeScore = (readyNodes / totalNodes) * 30;
-
-  const runningPods = health.pods.running;
-  const totalPods = Math.max(health.pods.total, 1);
-  const podScore = (runningPods / totalPods) * 40;
-
-  const crashPenalty = Math.min(health.pods.crash_looping * 5, 15);
-  const pendingPenalty = Math.min(health.pods.pending * 2, 10);
-  const warningPenalty = Math.min(health.recent_warnings.length * 0.5, 5);
-
-  const rows: { label: string; detail: string; value: string; negative?: boolean }[] = [
-    {
-      label: "Node health",
-      detail: `${readyNodes}/${health.nodes.length} ready`,
-      value: `+${nodeScore.toFixed(1)}`,
-    },
-    {
-      label: "Pod health",
-      detail: `${runningPods}/${health.pods.total} running`,
-      value: `+${podScore.toFixed(1)}`,
-    },
-    { label: "Base score", detail: "", value: "+30.0" },
-  ];
-
-  if (crashPenalty > 0) {
-    rows.push({
-      label: "CrashLoop penalty",
-      detail: `${health.pods.crash_looping} pod${health.pods.crash_looping !== 1 ? "s" : ""}`,
-      value: `-${crashPenalty.toFixed(1)}`,
-      negative: true,
-    });
-  }
-  if (pendingPenalty > 0) {
-    rows.push({
-      label: "Pending penalty",
-      detail: `${health.pods.pending} pod${health.pods.pending !== 1 ? "s" : ""}`,
-      value: `-${pendingPenalty.toFixed(1)}`,
-      negative: true,
-    });
-  }
-  if (warningPenalty > 0) {
-    rows.push({
-      label: "Warning penalty",
-      detail: `${health.recent_warnings.length} event${health.recent_warnings.length !== 1 ? "s" : ""}`,
-      value: `-${warningPenalty.toFixed(1)}`,
-      negative: true,
-    });
-  }
-
-  return (
-    <div className="mt-3 pt-3 border-t border-slate-800/60 space-y-1.5 text-[11px] font-mono">
-      {rows.map((row) => (
-        <div key={row.label} className="flex items-center gap-2">
-          <span className="text-slate-400 flex-1">{row.label}</span>
-          {row.detail && <span className="text-slate-600">{row.detail}</span>}
-          <span
-            className={cn(
-              "w-12 text-right tabular-nums font-medium",
-              row.negative ? "text-red-400/80" : "text-emerald-400/80",
-            )}
-          >
-            {row.value}
-          </span>
-        </div>
-      ))}
-      <div className="flex items-center gap-2 pt-1.5 border-t border-slate-800/40">
-        <span className="text-slate-300 flex-1 font-medium">Total</span>
-        <span
-          className={cn("w-12 text-right tabular-nums font-semibold", scoreColor(health.score))}
-        >
-          {health.score}
-        </span>
-      </div>
-      <p className="text-[10px] text-slate-600 leading-relaxed pt-1">
-        Score is clamped to 0-100. Node &amp; pod ratios scale up to 30 and 40 points respectively.
-        Penalties are capped at -15 (crash), -10 (pending), -5 (warnings).
-      </p>
-    </div>
-  );
-}
-
 // ── Health cards (shared between single and multi-cluster) ───────────
 
 function HealthCards({
@@ -201,12 +133,11 @@ function HealthCards({
   ].filter((d) => d.value > 0);
 
   const hasNoPods = podData.length === 0;
-  const [showBreakdown, setShowBreakdown] = useState(false);
 
   return (
     <>
       {/* ── Health Score ─────────────────────────────────────────── */}
-      <DashboardCard title="Cluster Health" icon={Heart}>
+      <DashboardCard title="Cluster Health" icon={Heart} tooltip="Score based on node readiness, pod health, and recent warning events.">
         <div className="flex flex-col items-center justify-center py-4">
           <div
             className={cn(
@@ -225,27 +156,7 @@ function HealthCards({
           <span className="text-xs text-slate-500 mt-1">
             {health.pods.total} pods across {health.nodes.length} nodes
           </span>
-          <button
-            onClick={() => setShowBreakdown((v) => !v)}
-            className="mt-2 flex items-center gap-1 text-[10px] text-slate-500 hover:text-slate-300 transition-colors"
-          >
-            <Info className="w-3 h-3" />
-            {showBreakdown ? "Hide breakdown" : "How is this calculated?"}
-          </button>
         </div>
-        <AnimatePresence>
-          {showBreakdown && (
-            <motion.div
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: "auto" }}
-              exit={{ opacity: 0, height: 0 }}
-              transition={{ duration: 0.2 }}
-              className="overflow-hidden"
-            >
-              <ScoreBreakdown health={health} />
-            </motion.div>
-          )}
-        </AnimatePresence>
       </DashboardCard>
 
       {/* ── Pod Health Pie ───────────────────────────────────────── */}

--- a/src/components/cluster-dashboard.tsx
+++ b/src/components/cluster-dashboard.tsx
@@ -17,6 +17,7 @@ import type { ClusterHealth, ClusterHealthEntry } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import {
   parseUsagePercent,
+  formatMemory,
   scoreColor,
   scoreBorderColor,
   scoreGlowColor,
@@ -257,7 +258,7 @@ function HealthCards({
                       />
                     </div>
                     <span className="w-20 text-right tabular-nums text-slate-400">
-                      {node.memory_usage || "?"} / {node.memory_capacity || "?"}
+                      {formatMemory(node.memory_usage)} / {formatMemory(node.memory_capacity)}
                     </span>
                   </div>
                 </div>

--- a/src/components/network-policy-view.tsx
+++ b/src/components/network-policy-view.tsx
@@ -176,9 +176,10 @@ function detectSimulation(text: string, groups: NetworkPolicyPodGroup[]): Simula
 interface NetworkPolicyViewProps {
   namespace?: string;
   currentContext?: string;
+  onGoToSettings?: () => void;
 }
 
-export function NetworkPolicyView({ namespace, currentContext }: NetworkPolicyViewProps) {
+export function NetworkPolicyView({ namespace, currentContext, onGoToSettings }: NetworkPolicyViewProps) {
   const { graph, loading, error, refresh, simulate } = useNetworkPolicyGraph(
     namespace,
     currentContext,
@@ -521,7 +522,7 @@ Total pods: ${allPods.length}`;
                 </p>
 
                 {!hasAIConfig && (
-                  <AIConfigWarning className="mb-6 rounded-lg border border-amber-500/30 max-w-sm" />
+                  <AIConfigWarning className="mb-6 rounded-lg border border-amber-500/30 max-w-sm" onGoToSettings={onGoToSettings} />
                 )}
 
                 {/* Suggested questions */}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -285,6 +285,8 @@ export interface WarningEvent {
   reason: string;
   message: string;
   involved_object: string;
+  object_kind: string;
+  object_name: string;
   namespace: string;
   count: number;
   last_seen: string;

--- a/src/lib/k8s-utils.ts
+++ b/src/lib/k8s-utils.ts
@@ -12,6 +12,19 @@ export function parseKubeQuantity(qty: string): number {
   return isNaN(num) ? 0 : num;
 }
 
+/** Format a K8s memory quantity (e.g. "8051048Ki") to human-readable (e.g. "7.7 Gi") */
+export function formatMemory(qty: string | undefined): string {
+  if (!qty) return "?";
+  const bytes = parseKubeQuantity(qty);
+  if (bytes === 0) return "0";
+  const gi = bytes / (1024 * 1024 * 1024);
+  if (gi >= 1) return `${gi.toFixed(1)} Gi`;
+  const mi = bytes / (1024 * 1024);
+  if (mi >= 1) return `${mi.toFixed(0)} Mi`;
+  const ki = bytes / 1024;
+  return `${ki.toFixed(0)} Ki`;
+}
+
 export function parseUsagePercent(usage: string | undefined, capacity: string | undefined): number {
   if (!usage || !capacity) return 0;
   const u = parseKubeQuantity(usage);


### PR DESCRIPTION
## Summary

- **Cluster Health tooltip**: Replace the expandable "How is this calculated?" section with a concise hover tooltip on the info icon
- **AI settings link**: Make "Settings" in the AI provider warning banner a clickable button that navigates directly to the Settings page
- **Memory formatting**: Format raw K8s memory quantities (e.g. `8051048Ki`) as human-readable values (e.g. `7.7 Gi`) in the Node Status card
- **Warning drill-down**: Make the involved object in Recent Warnings clickable, navigating to the resource's detail view for known resource kinds